### PR TITLE
Added on-prem-suite-parallel

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "docker-parallel": "npx wdio resources/conf/wdio-docker-parallel.conf.js",
     "on-prem-suite": "npx wdio resources/conf/wdio-on-prem-suite.conf.js",
     "on-prem": "npx wdio resources/conf/wdio-on-prem.conf.js",
+    "on-prem-suite-parallel": "npx wdio resources/conf/wdio-on-prem-suite-parallel.conf.js",
     "test": "npx wdio resources/conf/wdio-on-prem.conf.js",
     "generate-report": "./node_modules/allure-commandline/bin/allure generate allure-results --clean && ./node_modules/allure-commandline/bin/allure open"
   },

--- a/resources/conf/wdio-on-prem-suite-parallel.conf.js
+++ b/resources/conf/wdio-on-prem-suite-parallel.conf.js
@@ -1,0 +1,18 @@
+var defaults = require("./wdio.conf.js");
+var _ = require("lodash");
+
+var overrides = {
+  testData: [],
+  specs: [
+    './src/test/suites/login/*.js',
+    './src/test/suites/offers/*.js',
+    './src/test/suites/product/*.js',
+    './src/test/suites/e2e/*.js',
+    './src/test/suites/user/*.js'
+  ],
+  capabilities: [{
+    maxInstances: 5
+  }],
+};
+
+exports.config = _.defaultsDeep(overrides, defaults.config);


### PR DESCRIPTION
Added on-prem-suite-parallel conf where we can run all tested cases in parallel locally on-prem. This is added to keep in sync with the TestNG repo.